### PR TITLE
Renamed custom jwt lifespan property oauth.expriry -> oauth.expiry

### DIFF
--- a/src/main/java/net/whydah/commands/config/ConstantValue.java
+++ b/src/main/java/net/whydah/commands/config/ConstantValue.java
@@ -22,5 +22,5 @@ public class ConstantValue {
     
     public static final long DF_JWT_LIFESPAN = 3 * 60 * 60 * 1000; //1 hour;
     public static final boolean TOKEN_CUSTOM_EXPIRY_ENABLED = Configuration.getBoolean("token_custom_expiry");
-    public static final long CUSTOM_JWT_LIFESPAN = Long.valueOf(Configuration.getInt("oauth.expriry"));
+    public static final long CUSTOM_JWT_LIFESPAN = Long.valueOf(Configuration.getInt("oauth.expiry"));
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,4 +36,4 @@ oauth.dummy.applicationname=Whydah-SystemTests
 oauth.dummy.applicationsecret=55fhRM6nbKZ2wfC6RMmMuzXpk
 oauth.dummy.username=systest
 oauth.dummy.password=systest42
-oauth.expriry=86400000
+oauth.expiry=86400000


### PR DESCRIPTION
Misspelled property name. 
oauth.expriry changed to oauth.expiry 