### PR TITLE
fix(deps): revert jersey to 3.1.12 (v4 relocated AbstractBinder, compile break)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,11 @@
 		<jdk.version>21</jdk.version>
 		<service.name>Whydah-OAuth2Service</service.name>
 		<whydah-admin-sdk-version>3.1.12</whydah-admin-sdk-version>
-		<jersey.version>4.0.2</jersey.version>
+		<!-- Stay on the Jersey 3.1.x (jakarta) line: 4.0.x relocated
+		     org.glassfish.jersey.internal.inject.AbstractBinder, which
+		     JerseyConfig.java uses, so a 4.x bump fails to compile. Last release
+		     (2.31.25) shipped 3.1.11; 4 is a rewrite, not an auto-bump. -->
+		<jersey.version>3.1.12</jersey.version>
 		<jetty.version>12.0.20</jetty.version>
 		<slf4j.version>2.0.18</slf4j.version>
 		<hystrix.version>1.5.18</hystrix.version>

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cantara/Cantara-Renovate-Config"
+  ],
+  "packageRules": [
+    {
+      "description": "Stay on the Jersey 3.1.x line. Jersey 4.x relocated org.glassfish.jersey.internal.inject.AbstractBinder (used by JerseyConfig.java), so a 4.x bump fails to compile. Moving to Jersey 4 is a code migration, not an auto-bump; minor/patch within 3.1.x still flow. Remove only together with that migration.",
+      "matchPackagePatterns": ["^org\\.glassfish\\.jersey"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
`jersey.version` was bumped **3.1.11 → 4.0.2** (#789). Jersey 4.x relocated `org.glassfish.jersey.internal.inject.AbstractBinder`, which `JerseyConfig.java` extends, so the module stopped compiling — Jenkins #1506–1508 all failed at `cannot find symbol: AbstractBinder`. Last release (2.31.25) shipped **3.1.11**.

Revert to **3.1.12** (latest 3.1.x — jakarta, JDK 21, the established line) + a Renovate rule disabling Jersey **majors** (a code migration, not an auto-bump; minor/patch within 3.1.x flow).

Verified locally: `JerseyConfig` compiles clean. (The Jenkins release build runs `-DskipTests`, so compile is the gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)